### PR TITLE
Disable website maintenance mode via sql

### DIFF
--- a/disable-maintenance-mode.sql
+++ b/disable-maintenance-mode.sql
@@ -1,0 +1,27 @@
+-- Disable Maintenance Mode SQL Script
+-- This script will disable maintenance mode by updating the maintenance_settings table
+-- Run this script directly in your database to disable maintenance mode
+
+-- Method 1: Direct table update (if you have direct database access)
+UPDATE public.maintenance_settings 
+SET 
+  is_maintenance_mode = false,
+  ended_at = now(),
+  updated_at = now()
+WHERE id = (SELECT id FROM public.maintenance_settings LIMIT 1);
+
+-- Method 2: Using the toggle function (if you have service role access)
+-- SELECT public.toggle_maintenance_mode(false);
+
+-- Verify the change
+SELECT 
+  is_maintenance_mode,
+  maintenance_message,
+  maintenance_title,
+  started_at,
+  ended_at,
+  updated_at
+FROM public.maintenance_settings;
+
+-- Additional verification query
+SELECT public.get_maintenance_status();


### PR DESCRIPTION
Add `disable-maintenance-mode.sql` to provide a direct SQL script for disabling website maintenance mode when admin access is unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cf1f999-4e44-4b6c-8b2e-441158d893ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7cf1f999-4e44-4b6c-8b2e-441158d893ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>