### PR TITLE
Fix failing reset stats button in user management

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -242,26 +242,28 @@ export default function AdminPanel({ isOpen, onClose }: AdminPanelProps) {
     setResettingUser(true);
     try {
       // Reset basic profile statistics (only columns that exist in profiles table)
+      const updateData = {
+        level: 1,
+        xp: 0,
+        total_wagered: 0,
+        total_profit: 0
+      };
+      
+      console.log('Updating profiles with data:', updateData);
+      
       const { error: profileError } = await supabase
         .from('profiles')
-        .update({
-          level: 1,
-          xp: 0,
-          total_wagered: 0,
-          total_profit: 0,
-          current_level: 1,
-          current_xp: 0,
-          xp_to_next_level: 100,
-          lifetime_xp: 0,
-          border_tier: 1,
-          available_cases: 0,
-          total_cases_opened: 0,
-          total_xp: 0
-        })
+        .update(updateData)
         .eq('id', userId);
 
       if (profileError) {
         console.error('Error resetting profile stats:', profileError);
+        console.error('Error details:', {
+          code: profileError.code,
+          message: profileError.message,
+          details: profileError.details,
+          hint: profileError.hint
+        });
         toast({
           title: "Error",
           description: "Failed to reset user profile statistics",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes the admin panel's 'Reset Stats' button functionality and resolves accessibility warnings for dialogs.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The 'Reset Stats' button previously failed due to attempts to update non-existent columns in the `profiles` table. This PR corrects the database operations to target the appropriate `profiles` and `user_level_stats` tables, ensuring a comprehensive reset of all user-related data (including game stats, achievements, and notifications). It also adds `DialogDescription` to all `DialogContent` components, resolving accessibility warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0326f42-adba-4209-bc6f-acb0edc8047e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0326f42-adba-4209-bc6f-acb0edc8047e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>